### PR TITLE
Reduce access visibility of helper class constructors and constants.

### DIFF
--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotPathView.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotPathView.java
@@ -65,12 +65,12 @@ class IndicatorDotPathView extends ViewGroup {
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({PATH_DIRECTION_LEFT, PATH_DIRECTION_RIGHT})
-    public @interface PathDirection {}
+    @interface PathDirection {}
 
     @PathDirection
-    public static final int PATH_DIRECTION_LEFT = 0;
+    static final int PATH_DIRECTION_LEFT = 0;
     @PathDirection
-    public static final int PATH_DIRECTION_RIGHT = 1;
+    static final int PATH_DIRECTION_RIGHT = 1;
 
     //endregion
 
@@ -102,7 +102,7 @@ class IndicatorDotPathView extends ViewGroup {
 
     //region Constructors
 
-    public IndicatorDotPathView(@NonNull Context context) {
+    IndicatorDotPathView(@NonNull Context context) {
         super(context);
 
         final float scale = context.getResources().getDisplayMetrics().density;
@@ -120,7 +120,7 @@ class IndicatorDotPathView extends ViewGroup {
         init(DEFAULT_DOT_COLOR);
     }
 
-    public IndicatorDotPathView(@NonNull Context context,
+    IndicatorDotPathView(@NonNull Context context,
                                 @ColorInt int dotColor,
                                 @Px int dotPadding,
                                 @Px int dotRadius) {
@@ -496,7 +496,7 @@ class IndicatorDotPathView extends ViewGroup {
          * @return An animator.
          */
         @NonNull
-        public Animator stretchAnimator(long animationDuration, final float toX, final float toY) {
+        Animator stretchAnimator(long animationDuration, final float toX, final float toY) {
             // Since the provided coordinates are in this view's coordinate space, the absolute distance
             // to the coordinate is the value of the coordinate itself.
             final float distanceX = Math.abs(toX) + (toX < 0 ? getWidth() : 0);

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotView.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotView.java
@@ -69,23 +69,23 @@ class IndicatorDotView extends ImageView {
 
     //region Constructors
 
-    public IndicatorDotView(@NonNull Context context) {
+    IndicatorDotView(@NonNull Context context) {
         super(context);
         init(context, null, 0, 0);
     }
 
-    public IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs) {
+    IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
         init(context, attrs, 0, 0);
     }
 
-    public IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(context, attrs, defStyleAttr, 0);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    IndicatorDotView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         init(context, attrs, defStyleAttr, defStyleRes);
     }


### PR DESCRIPTION
There should be no need for library consumers to use these members.