### PR TITLE
Don't use 🍭Lollipop+ constructor.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,9 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-DEBUG"
+
             minifyEnabled false
             shrinkResources false
             useProguard false

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -160,7 +160,7 @@ public class ViewPagerIndicator extends ViewGroup {
 
         attributes.recycle();
 
-        selectedDot = new IndicatorDotView(context, null, defStyleAttr, defStyleRes);
+        selectedDot = new IndicatorDotView(context);
         selectedDot.setColor(selectedDotColor);
         selectedDot.setRadius(dotRadius);
     }


### PR DESCRIPTION
Addresses part of #6.