### PR TITLE
Slow scrolling bugfix

### DIFF
--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -556,11 +556,11 @@ public class ViewPagerIndicator extends ViewGroup {
 
         @Override
         public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-            if (positionOffset > 0.5f) {
-                // Consider ourselves to be on the next page when we're 50% of the way there.
-                position++;
-            }
-            updateIndicatorPositions(position, positionOffset, false);
+//            if (positionOffset > 0.5f) {
+//                // Consider ourselves to be on the next page when we're 50% of the way there.
+//                position++;
+//            }
+//            updateIndicatorPositions(position, positionOffset, false);
         }
 
         @Override
@@ -574,6 +574,7 @@ public class ViewPagerIndicator extends ViewGroup {
             if (pageChangeAnimator != null) {
                 pageChangeAnimator.start();
             }
+            lastKnownCurrentPage = position;
         }
 
         @Override

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -556,11 +556,7 @@ public class ViewPagerIndicator extends ViewGroup {
 
         @Override
         public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-//            if (positionOffset > 0.5f) {
-//                // Consider ourselves to be on the next page when we're 50% of the way there.
-//                position++;
-//            }
-//            updateIndicatorPositions(position, positionOffset, false);
+            //do nothing
         }
 
         @Override
@@ -574,6 +570,7 @@ public class ViewPagerIndicator extends ViewGroup {
             if (pageChangeAnimator != null) {
                 pageChangeAnimator.start();
             }
+            //update lastKnownCurrentPage here
             lastKnownCurrentPage = position;
         }
 


### PR DESCRIPTION
bugfix about. https://github.com/ronaldsmartin/Material-ViewPagerIndicator/issues/14

I don't know why you must use Google's code.
I just update **lastKnownCurrentPage** in PagerListener::onPageSelected , and the bug fixed.