### PR TITLE
Add new animation types

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
 
-        versionCode 2
-        versionName "1.0.1"
+        versionCode 3
+        versionName "1.0.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/30/16 6:12 PM.
+ * Last modified 11/19/16 10:26 AM.
  */
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -44,7 +44,7 @@ ext {
     compileSdkVersion = 24
     minSdkVersion = 11
     targetSdkVersion = 24
-    buildToolsVersion = "24.0.2"
+    buildToolsVersion = "25"
 }
 
 ext.deps = [

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/12/16 11:22 PM.
+ * Last modified 10/30/16 6:12 PM.
  */
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/material-viewpagerindicator/build.gradle
+++ b/material-viewpagerindicator/build.gradle
@@ -25,8 +25,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.1"
+        versionCode 3
+        versionName "1.0.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotPathView.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/IndicatorDotPathView.java
@@ -506,7 +506,8 @@ class IndicatorDotPathView extends ViewGroup {
             final float scaleY = distanceY / getHeight();
             final float originalScale = 1;
 
-            final Animator animator = scaleAnimator(this, originalScale, scaleX, scaleY);
+            final Animator animator = IndicatorDotPathView
+                    .scaleAnimator(this, originalScale, scaleX, scaleY);
 
             animator.setDuration(animationDuration);
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/12/16 11:22 PM.
+ * Last modified 10/29/16 10:41 PM.
  */
 
 package com.itsronald.widget;
@@ -29,6 +29,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.Dimension;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Px;
@@ -41,9 +42,12 @@ import android.view.Gravity;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+import java.lang.annotation.Retention;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * ViewPagerIndicator is a non-interactive indicator of the current, next,
@@ -57,10 +61,43 @@ import java.util.List;
 @ViewPager.DecorView
 public class ViewPagerIndicator extends ViewGroup {
 
+    //region Constants
+
     @NonNull
     private static final String TAG = "ViewPagerIndicator";
     
     private static final long DOT_SLIDE_ANIM_DURATION = 150;    // 150 ms.
+
+    /**
+     * Indicator animation styles.
+     * <p>
+     * You can use #getAnimationStyle() and #setAnimationStyle(int) in conjunction with these
+     * values to control the indicator's page change animations.
+     */
+    @IntDef({ANIMATION_STYLE_NONE, ANIMATION_STYLE_INK, ANIMATION_STYLE_SCALE})
+    @Retention(SOURCE)
+    public @interface AnimationStyle {
+    }
+
+    /**
+     * Indicator animation style: The selected dot changes colors with no animation.
+     */
+    public static final int ANIMATION_STYLE_NONE = 0;
+    /**
+     * Indicator animation style: The selected dot slides along a dynamic path that collapses
+     * behind it.
+     * <p>
+     * This is the default animation style.
+     */
+    public static final int ANIMATION_STYLE_INK = 1;
+    /**
+     * Indicator animation style: The selected dot is slightly larger than the unselected dots.
+     * When the page changes, the dot for the new page grows and changes color, while the dot for
+     * the old page shifts to match the other unselected page dots.
+     */
+    public static final int ANIMATION_STYLE_SCALE = 2;
+
+    //endregion
 
     //region ViewPager
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -275,7 +275,8 @@ public class ViewPagerIndicator extends ViewGroup {
             height = MeasureSpec.getSize(heightMeasureSpec);
         } else {
             final int indicatorHeight = selectedDot.getMeasuredHeight();
-            final float maxScale = Math.max(unselectedDotScale, selectedDotScale);
+            final float maxScale = animationStyle == ANIMATION_STYLE_SCALE ?
+                    Math.max(unselectedDotScale, selectedDotScale) : 1;
             final int maxScaledIndicatorHeight = (int) (indicatorHeight * maxScale);
 
             final int minHeight = ViewCompat.getMinimumHeight(this);

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -33,6 +33,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Px;
+import android.support.annotation.UiThread;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPager;
@@ -881,6 +882,62 @@ public class ViewPagerIndicator extends ViewGroup {
             selectedDot.setColor(color);
             selectedDot.invalidate();
         }
+    }
+
+    /**
+     * Get the current size scale factor for unselected indicator dots.
+     * This value is not used unless the current animation style is {@code ANIMATION_STYLE_SCALE}.
+     *
+     * @see #setUnselectedDotScale(float)
+     *
+     * @return The size scale for unselected page dots.
+     */
+    public float getUnselectedDotScale() {
+        return unselectedDotScale;
+    }
+
+    /**
+     * Set the size scale factor for unselected indicator dots.
+     * This value is not used unless the current animation style is {@code ANIMATION_STYLE_SCALE}.
+     *
+     * @see #getUnselectedDotScale()
+     */
+    @UiThread
+    public void setUnselectedDotScale(float unselectedDotScale) {
+        if (this.unselectedDotScale == unselectedDotScale) return;
+        if (unselectedDotScale < 0) unselectedDotScale = 0;
+
+        this.unselectedDotScale = unselectedDotScale;
+        invalidate();
+        requestLayout();
+    }
+
+    /**
+     * Get the current size scale factor for the selected indicator dot.
+     * This value is not used unless the current animation style is {@code ANIMATION_STYLE_SCALE}.
+     *
+     * @see #setSelectedDotScale(float)
+     *
+     * @return The size scale for the selected page dot.
+     */
+    public float getSelectedDotScale() {
+        return selectedDotScale;
+    }
+
+    /**
+     * Set the size scale factor for the selected indicator dot.
+     * This value is not used unless the current animation style is {@code ANIMATION_STYLE_SCALE}.
+     *
+     * @see #getSelectedDotScale()
+     */
+    @UiThread
+    public void setSelectedDotScale(float selectedDotScale) {
+        if (this.selectedDotScale == selectedDotScale) return;
+        if (selectedDotScale < 0) selectedDotScale = 0;
+
+        this.selectedDotScale = selectedDotScale;
+        invalidate();
+        requestLayout();
     }
 
     /**

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/29/16 11:25 PM.
+ * Last modified 10/29/16 11:37 PM.
  */
 
 package com.itsronald.widget;
@@ -597,6 +597,16 @@ public class ViewPagerIndicator extends ViewGroup {
         return animator;
     }
 
+    private void layoutPageChangeImmediate(int newPageIndex) {
+        final Rect dotRect = new Rect();
+        final IndicatorDotView newPageDot = getDotForPage(newPageIndex);
+        if (newPageDot != null) {
+            newPageDot.getDrawingRect(dotRect);
+            offsetDescendantRectToMyCoords(newPageDot, dotRect);
+            selectedDot.layout(dotRect.left, dotRect.top, dotRect.right, dotRect.bottom);
+        }
+    }
+
     /**
      * Watches the ViewPager for changes, updating the indicator as needed.
      */
@@ -630,7 +640,9 @@ public class ViewPagerIndicator extends ViewGroup {
                 refresh();
             }
 
-            if (pageChangeAnimator != null) {
+            if (pageChangeAnimator == null) {
+                layoutPageChangeImmediate(position);
+            } else {
                 pageChangeAnimator.start();
             }
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/29/16 11:37 PM.
+ * Last modified 11/19/16 3:10 PM.
  */
 
 package com.itsronald.widget;
@@ -769,6 +769,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getGravity()
      */
+    @UiThread
     public void setGravity(int newGravity) {
         gravity = newGravity;
         requestLayout();
@@ -793,6 +794,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getDotPadding()
      */
+    @UiThread
     public void setDotPadding(@Px int newDotPadding) {
         if (dotPadding == newDotPadding) return;
         if (newDotPadding < 0) newDotPadding = 0;
@@ -821,6 +823,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getDotRadius()
      */
+    @UiThread
     public void setDotRadius(@Px int newRadius) {
         if (dotRadius == newRadius) return;
         if (newRadius < 0) newRadius = 0;
@@ -852,6 +855,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getUnselectedDotColor()
      */
+    @UiThread
     public void setUnselectedDotColor(@ColorInt int color) {
         unselectedDotColor = color;
         for (IndicatorDotView indicatordot : indicatorDots) {
@@ -879,6 +883,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getSelectedDotColor()
      */
+    @UiThread
     public void setSelectedDotColor(@ColorInt int color) {
         selectedDotColor = color;
         if (selectedDot != null) {
@@ -963,6 +968,7 @@ public class ViewPagerIndicator extends ViewGroup {
      *
      * @see #getAnimationStyle()
      */
+    @UiThread
     public void setAnimationStyle(@AnimationStyle int animationStyle) {
         this.animationStyle = animationStyle;
         invalidate();

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -650,6 +650,7 @@ public class ViewPagerIndicator extends ViewGroup {
                 lastDot.colorAnimator(unselectedDotColor),
                 newDot.colorAnimator(selectedDotColor)
         );
+        animatorSet.setDuration(animationDuration);
         return animatorSet;
     }
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -462,7 +462,9 @@ public class ViewPagerIndicator extends ViewGroup {
      * @param positionOffset The offset of the current page from horizontal center.
      * @param forceUpdate    Whether or not to force an update
      */
-    private void updateIndicatorPositions(int currentPage, float positionOffset, boolean forceUpdate) {
+    private void updateIndicatorPositions(int currentPage,
+                                          float positionOffset,
+                                          boolean forceUpdate) {
         if (currentPage != lastKnownCurrentPage && viewPager != null) {
             updateIndicators(currentPage, viewPager.getAdapter());
         } else if (!forceUpdate && positionOffset == lastKnownPositionOffset) {
@@ -476,9 +478,8 @@ public class ViewPagerIndicator extends ViewGroup {
         final int bottom = top + dotWidth;
         int left = calculateIndicatorDotStart();
         int right = left + dotWidth;
-        for (int i = 0,
-             dotCount = indicatorDots.size(),
-             pathCount = dotPaths.size(); i < dotCount; ++i) {
+        for (int i = 0, dotCount = indicatorDots.size(), pathCount = dotPaths.size();
+                i < dotCount; ++i) {
             final IndicatorDotView dotView = indicatorDots.get(i);
             dotView.layout(left, top, right, bottom);
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/29/16 11:02 PM.
+ * Last modified 10/29/16 11:14 PM.
  */
 
 package com.itsronald.widget;
@@ -518,7 +518,20 @@ public class ViewPagerIndicator extends ViewGroup {
     }
 
     @Nullable
-    private Animator pageChangeAnimator(final int lastPageIndex, final int newPageIndex) {
+    private Animator getPageChangeAnimator(final int lastPageIndex, final int newPageIndex) {
+        switch (getAnimationStyle()) {
+            case ANIMATION_STYLE_INK:
+                return getInkPageChangeAnimator(lastPageIndex, newPageIndex);
+            case ANIMATION_STYLE_SCALE:
+                Log.w(TAG, "Unimplemented");
+            case ANIMATION_STYLE_NONE:
+            default:
+                return null;
+        }
+    }
+
+    @Nullable
+    private Animator getInkPageChangeAnimator(final int lastPageIndex, final int newPageIndex) {
         final IndicatorDotPathView dotPath = getDotPathForPageChange(lastPageIndex, newPageIndex);
         final IndicatorDotView lastDot = getDotForPage(lastPageIndex);
 
@@ -598,21 +611,25 @@ public class ViewPagerIndicator extends ViewGroup {
 
         @Override
         public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-            //do nothing
+            // No action necessary - animations will be triggered only when the page has changed
+            // completely.
         }
 
         @Override
         public void onPageSelected(int position) {
-            final Animator pageChangeAnimator = pageChangeAnimator(lastKnownCurrentPage, position);
+            final Animator pageChangeAnimator =
+                    getPageChangeAnimator(lastKnownCurrentPage, position);
+
             if (scrollState == ViewPager.SCROLL_STATE_IDLE
                     && viewPager != null) {
                 // Only update the text here if we're not dragging or settling.
                 refresh();
             }
+
             if (pageChangeAnimator != null) {
                 pageChangeAnimator.start();
             }
-            //update lastKnownCurrentPage here
+
             lastKnownCurrentPage = position;
         }
 

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/29/16 11:14 PM.
+ * Last modified 10/29/16 11:25 PM.
  */
 
 package com.itsronald.widget;
@@ -71,8 +71,9 @@ public class ViewPagerIndicator extends ViewGroup {
     /**
      * Indicator animation styles.
      * <p>
-     * You can use #getAnimationStyle() and #setAnimationStyle(int) in conjunction with these
-     * values to control the indicator's page change animations.
+     * You can use {@link #getAnimationStyle()} and {@link #setAnimationStyle(int)} in conjunction
+     * with these values or the {@code animationStyle} XML styleable attribute to control the
+     * indicator's page change animations.
      */
     @IntDef({ANIMATION_STYLE_NONE, ANIMATION_STYLE_INK, ANIMATION_STYLE_SCALE})
     @Retention(SOURCE)
@@ -81,6 +82,7 @@ public class ViewPagerIndicator extends ViewGroup {
     /**
      * Indicator animation style: The selected dot changes colors with no animation.
      */
+    @AnimationStyle
     public static final int ANIMATION_STYLE_NONE = 0;
     /**
      * Indicator animation style: The selected dot slides along a dynamic path that collapses
@@ -88,12 +90,14 @@ public class ViewPagerIndicator extends ViewGroup {
      * <p>
      * This is the default animation style.
      */
+    @AnimationStyle
     public static final int ANIMATION_STYLE_INK = 1;
     /**
      * Indicator animation style: The selected dot is slightly larger than the unselected dots.
      * When the page changes, the dot for the new page grows and changes color, while the dot for
      * the old page shifts to match the other unselected page dots.
      */
+    @AnimationStyle
     public static final int ANIMATION_STYLE_SCALE = 2;
 
     //endregion
@@ -234,9 +238,9 @@ public class ViewPagerIndicator extends ViewGroup {
         final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         if (widthMode == MeasureSpec.EXACTLY) {
             /*
-             * Due to the implementation of onMeasure() in ViewPager, this case will always be
-             * called if vertical layout_gravity is specified on this view. Since the Material
-             * Design spec usually positions dot indicators like this at the bottom of pages, this
+             * Due to the implementation of onMeasure() in ViewPager, this case will be called if
+             * vertical layout_gravity is specified on this view. Since the Material Design spec
+             * usually positions dot indicators like this at the bottom of pages, that means this
              * case will be called almost all the time.
              */
             width = MeasureSpec.getSize(widthMeasureSpec);
@@ -680,6 +684,8 @@ public class ViewPagerIndicator extends ViewGroup {
     /**
      * Get the {@link Gravity} used to position dots within the indicator.
      * Only the vertical gravity component is used.
+     *
+     * @see #setGravity(int)
      */
     public int getGravity() {
         return gravity;
@@ -690,6 +696,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Only the vertical gravity component is used.
      *
      * @param newGravity {@link Gravity} constant for positioning indicator dots.
+     *
+     * @see #getGravity()
      */
     public void setGravity(int newGravity) {
         gravity = newGravity;
@@ -700,6 +708,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Get the current spacing between each indicator dot.
      *
      * @return The distance between each indicator dot, in pixels.
+     *
+     * @see #setDotPadding(int)
      */
     @Px
     public int getDotPadding() {
@@ -710,6 +720,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Set the spacing between each indicator dot.
      *
      * @param newDotPadding The distance to use between each indicator dot, in pixels.
+     *
+     * @see #getDotPadding()
      */
     public void setDotPadding(@Px int newDotPadding) {
         if (dotPadding == newDotPadding) return;
@@ -724,6 +736,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Get the current radius of each indicator dot.
      *
      * @return The radius of each indicator dot, in pixels.
+     *
+     * @see #setDotRadius(int)
      */
     @Px
     public int getDotRadius() {
@@ -734,6 +748,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Set the radius of each indicator dot.
      *
      * @param newRadius The new radius to use for each indicator dot.
+     *
+     * @see #getDotRadius()
      */
     public void setDotRadius(@Px int newRadius) {
         if (dotRadius == newRadius) return;
@@ -751,6 +767,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Get the current color for unselected indicator dots.
      *
      * @return The unselected dot color.
+     *
+     * @see #setUnselectedDotColor(int)
      */
     @ColorInt
     public int getUnselectedDotColor() {
@@ -761,6 +779,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Set the current color for unselected indicator dots.
      *
      * @param color The new unselected dot color to use.
+     *
+     * @see #getUnselectedDotColor()
      */
     public void setUnselectedDotColor(@ColorInt int color) {
         unselectedDotColor = color;
@@ -774,6 +794,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Get the current color for selected indicator dots.
      *
      * @return The selected dot color.
+     *
+     * @see #setUnselectedDotColor(int)
      */
     @ColorInt
     public int getSelectedDotColor() {
@@ -784,6 +806,8 @@ public class ViewPagerIndicator extends ViewGroup {
      * Set the current color for selected indicator dots.
      *
      * @param color The new selected dot color to use.
+     *
+     * @see #getSelectedDotColor()
      */
     public void setSelectedDotColor(@ColorInt int color) {
         selectedDotColor = color;

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -100,6 +100,10 @@ public class ViewPagerIndicator extends ViewGroup {
     @AnimationStyle
     public static final int ANIMATION_STYLE_SCALE = 2;
 
+    private static float DEFAULT_DOT_SCALE_SELECTED = 1.5f;
+
+    private static float DEFAULT_DOT_SCALE_UNSELECTED = 1f;
+
     //endregion
 
     //region ViewPager
@@ -131,8 +135,8 @@ public class ViewPagerIndicator extends ViewGroup {
     private int unselectedDotColor;
     @ColorInt
     private int selectedDotColor;
-    private float unselectedDotScale = 1;
-    private float selectedDotScale = 1.5f;
+    private float unselectedDotScale;
+    private float selectedDotScale;
     private int animationStyle;
 
     //endregion
@@ -200,6 +204,15 @@ public class ViewPagerIndicator extends ViewGroup {
         selectedDotColor = attributes.getColor(
                 R.styleable.ViewPagerIndicator_selectedDotColor,
                 IndicatorDotView.DEFAULT_SELECTED_DOT_COLOR
+        );
+
+        unselectedDotScale = attributes.getFloat(
+                R.styleable.ViewPagerIndicator_unselectedDotScale,
+                DEFAULT_DOT_SCALE_UNSELECTED
+        );
+        selectedDotScale = attributes.getFloat(
+                R.styleable.ViewPagerIndicator_selectedDotScale,
+                DEFAULT_DOT_SCALE_SELECTED
         );
 
         animationStyle = attributes.getInt(

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Last modified 10/29/16 10:41 PM.
+ * Last modified 10/29/16 11:02 PM.
  */
 
 package com.itsronald.widget;
@@ -76,8 +76,7 @@ public class ViewPagerIndicator extends ViewGroup {
      */
     @IntDef({ANIMATION_STYLE_NONE, ANIMATION_STYLE_INK, ANIMATION_STYLE_SCALE})
     @Retention(SOURCE)
-    public @interface AnimationStyle {
-    }
+    public @interface AnimationStyle {}
 
     /**
      * Indicator animation style: The selected dot changes colors with no animation.
@@ -127,6 +126,7 @@ public class ViewPagerIndicator extends ViewGroup {
     private int unselectedDotColor;
     @ColorInt
     private int selectedDotColor;
+    private int animationStyle;
 
     //endregion
 
@@ -193,6 +193,11 @@ public class ViewPagerIndicator extends ViewGroup {
         selectedDotColor = attributes.getColor(
                 R.styleable.ViewPagerIndicator_selectedDotColor,
                 IndicatorDotView.DEFAULT_SELECTED_DOT_COLOR
+        );
+
+        animationStyle = attributes.getInt(
+                R.styleable.ViewPagerIndicator_animationStyle,
+                ANIMATION_STYLE_INK
         );
 
         attributes.recycle();
@@ -769,6 +774,32 @@ public class ViewPagerIndicator extends ViewGroup {
             selectedDot.setColor(color);
             selectedDot.invalidate();
         }
+    }
+
+    /**
+     * Get the current animation style used for page changes.
+     *
+     * @return The {@link AnimationStyle} currently being used when the indicator changes pages.
+     *
+     * @see #setAnimationStyle(int)
+     */
+    @AnimationStyle
+    public int getAnimationStyle() {
+        return animationStyle;
+    }
+
+    /**
+     * Set a new page change animation style for the indicator.
+     *
+     * @param animationStyle The animation to use when the ViewPager page is changed.
+     *                       Supported values can be found in {@link AnimationStyle}.
+     *
+     * @see #getAnimationStyle()
+     */
+    public void setAnimationStyle(@AnimationStyle int animationStyle) {
+        this.animationStyle = animationStyle;
+        invalidate();
+        requestLayout();
     }
 
     //endregion

--- a/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
+++ b/material-viewpagerindicator/src/main/java/com/itsronald/widget/ViewPagerIndicator.java
@@ -556,11 +556,7 @@ public class ViewPagerIndicator extends ViewGroup {
 
         @Override
         public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-            if (positionOffset > 0.5f) {
-                // Consider ourselves to be on the next page when we're 50% of the way there.
-                position++;
-            }
-            updateIndicatorPositions(position, positionOffset, false);
+            //do nothing
         }
 
         @Override
@@ -574,6 +570,8 @@ public class ViewPagerIndicator extends ViewGroup {
             if (pageChangeAnimator != null) {
                 pageChangeAnimator.start();
             }
+            //update lastKnownCurrentPage here
+            lastKnownCurrentPage = position;
         }
 
         @Override

--- a/material-viewpagerindicator/src/main/res/values/attrs.xml
+++ b/material-viewpagerindicator/src/main/res/values/attrs.xml
@@ -24,12 +24,23 @@
     <declare-styleable name="ViewPagerIndicator">
         <!-- Standard gravity attribute. Only the vertical dimension is used. -->
         <attr name="android:gravity" />
-        <!-- Indicator sizing -->
+
+        <!-- Half the width and height of each indicator dot. -->
         <attr name="dotRadius" />
+        <!-- Spacing between each dot.-->
         <attr name="dotPadding" format="dimension" />
-        <!-- Indicator dot and path colors. The path color is the same as the unselected color. -->
+        <!-- The dot color for the selected page. -->
         <attr name="selectedDotColor" format="color" />
+        <!-- Indicator dot and path color. -->
         <attr name="unselectedDotColor" format="color" />
+        <!-- Size scale factor used for the selected page dot.
+             This value is only used with the "scale" animation style.
+             The default is 1.5. -->
+        <attr name="selectedDotScale" format="float" />
+        <!-- Size scale factor used for unselected page dots.
+             This value is only used with the "scale" animation style.
+             The default is 1.0. -->
+        <attr name="unselectedDotScale" format="float" />
         <!--
         Supported animation types:
 

--- a/material-viewpagerindicator/src/main/res/values/attrs.xml
+++ b/material-viewpagerindicator/src/main/res/values/attrs.xml
@@ -14,20 +14,41 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~
-  ~ Last modified 10/12/16 11:22 PM.
+  ~ Last modified 10/29/16 10:11 PM.
   -->
 
 <resources>
     <attr name="dotRadius" format="dimension" />
 
+    <!-- Public styleable attributes for customizing indicators. -->
     <declare-styleable name="ViewPagerIndicator">
+        <!-- Standard gravity attribute. Only the vertical dimension is used. -->
         <attr name="android:gravity" />
+        <!-- Indicator sizing -->
         <attr name="dotRadius" />
         <attr name="dotPadding" format="dimension" />
+        <!-- Indicator dot and path colors. The path color is the same as the unselected color. -->
         <attr name="selectedDotColor" format="color" />
         <attr name="unselectedDotColor" format="color" />
+        <!--
+        Supported animation types:
+
+             1. None   The selected dot changes colors with no animation.
+             2. Ink    (Default) A Material Design animation in which the selected dot slides along
+                       a dynamic path that collapses behind it.
+             3. Scale  The selected dot is slightly larger than the unselected dots. When the page
+                       changes, the dot for the new page grows and changes color, while the dot for
+                       the old page shifts to match the other unselected page dots.
+                       (As seen in the stock launcher and Google News & Weather.)
+        -->
+        <attr name="animationStyle" format="enum">
+            <enum name="none" value="0" />
+            <enum name="ink" value="1" />
+            <enum name="scale" value="2" />
+        </attr>
     </declare-styleable>
 
+    <!-- Internal styleable attributes for debugging individual dots. -->
     <declare-styleable name="IndicatorDotView">
         <attr name="dotRadius" />
         <attr name="dotColor" format="color" />


### PR DESCRIPTION
Adds the animation types proposed in #4:

* `ANIMATION_STYLE_NONE`: No animation, like the original ViewPagerIndicator library and iOS's `UIPageControl`.
* `ANIMATION_STYLE_INK`: The original (and default) ink path animation
* `ANIMATION_STYLE_SCALE`: The dot color/scale animation currently used in the Google News & Weather app.

These can be set using either the `animationStyle` XML property in layouts or the `setAnimationStyle(@AnimationStyle int)` method.